### PR TITLE
Added SendGrid key to deployment

### DIFF
--- a/.github/workflows/az-deploy.yml
+++ b/.github/workflows/az-deploy.yml
@@ -21,6 +21,9 @@ on:
       IDS_URL:
         required: true
         type: string
+      SENDGRID_KEY:
+        required: true
+        type: string
     secrets:
       AZURE_CREDENTIALS:
         required: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
       APP_SERVICE_PLAN_RESOURCE_GROUP: SSW.AppServicePlans
       ADMIN_PORTAL_URL: https://dev.rewards.ssw.com.au
       IDS_URL: https://app-ssw-ident-staging-api.azurewebsites.net
+      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
@@ -37,6 +38,7 @@ jobs:
       # TODO: Correct the Admin Portal URL when we have a staging env
       ADMIN_PORTAL_URL: https://dev.rewards.ssw.com.au
       IDS_URL: https://app-ssw-ident-staging-api.azurewebsites.net
+      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
@@ -53,6 +55,7 @@ jobs:
       APP_SERVICE_PLAN_RESOURCE_GROUP: SSW.AppServicePlans
       ADMIN_PORTAL_URL: https://rewards.ssw.com.au
       IDS_URL: https://identity.ssw.com.au
+      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,6 +19,9 @@ param adminPortalUrl string
 param idsUrl string
 
 @secure()
+param sendGridKey string
+
+@secure()
 @description('Specifies secrets to connect to apple https://docs.microsoft.com/en-us/azure/templates/microsoft.notificationhubs/namespaces/notificationhubs?tabs=bicep#apnscredentialproperties Sample: {"keyId":"key id","appName":"bundle id","appId":"team id","token":"token"}')
 param notificationHubAppleCredential object = {}
 
@@ -64,6 +67,8 @@ module appService 'modules/webapp.bicep' = {
     keyVaultName: keyVault.outputs.keyVaultName
     adminPortalUrl: adminPortalUrl
     idsUrl: idsUrl
+    now: now
+    sendGridKey: sendGridKey
   }
 }
 

--- a/infra/modules/webapp.bicep
+++ b/infra/modules/webapp.bicep
@@ -5,6 +5,17 @@ param keyVaultName string
 param appServicePlanId string
 param adminPortalUrl string
 param idsUrl string
+param sendGridKey string
+param now string
+
+module sendGridSecrets 'create-secrets.bicep' = {
+  name: 'sendGridSecrets-${now}'
+  params: {
+    keyVaultName: keyVaultName
+    secretName: 'SendGridAPIKey'
+    secretValue: sendGridKey
+  }
+}
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: 'ai-${projectName}-${environment}'


### PR DESCRIPTION
Added as a repository secret as there's only one SendGrid key for use in all environments (and all apps, that's a different SysAdmin conversation though...)
<img width="617" alt="image" src="https://user-images.githubusercontent.com/19944129/192401098-fd4b9f0f-efeb-46e2-bc97-540b5b3bd61d.png">
