### PR TITLE
Add prize draw

### DIFF
--- a/src/SSW.Rewards.Application/Achievements/Command/CreateAchievement/CreateAchievementCommandValidator.cs
+++ b/src/SSW.Rewards.Application/Achievements/Command/CreateAchievement/CreateAchievementCommandValidator.cs
@@ -5,6 +5,5 @@ public class CreateAchievementCommandValidator : AbstractValidator<CreateAchieve
     public CreateAchievementCommandValidator()
     {
         RuleFor(x => x.Name).NotEmpty().MaximumLength(128);
-        RuleFor(x => x.Value).NotEmpty().LessThan(1000);
     }
 }

--- a/src/SSW.Rewards.Application/Common/Extensions/DateTimeExtensions.cs
+++ b/src/SSW.Rewards.Application/Common/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Globalization;
+
+namespace SSW.Rewards.Application.Common.Extensions;
+
+public static class DateTimeExtensions
+{
+    public static DateTime FirstDayOfWeek(this DateTime dt)
+    {
+        var culture = CultureInfo.CurrentCulture;
+        // (monday to sunday)
+        var diff = dt.DayOfWeek - culture.DateTimeFormat.FirstDayOfWeek;
+        if (diff < 0)
+            diff += 7;
+        return dt.AddDays(-diff).Date;
+    }
+
+    public static bool IsBetween(this DateTime dt, DateTime start, DateTime end)
+    {
+        return start <= dt && dt <= end;
+    }
+}

--- a/src/SSW.Rewards.Application/Leaderboard/Queries/Common/LeaderboardUserDto.cs
+++ b/src/SSW.Rewards.Application/Leaderboard/Queries/Common/LeaderboardUserDto.cs
@@ -15,7 +15,7 @@ public class LeaderboardUserDto : IMapFrom<User>
 
     public int TotalPoints { get; set; }
 
-    public int Balance { get; set; }
+    public int PointsClaimed { get; set; }
 
     public int PointsToday { get; set; }
 
@@ -24,6 +24,8 @@ public class LeaderboardUserDto : IMapFrom<User>
     public int PointsThisMonth { get; set; }
 
     public int PointsThisYear { get; set; }
+
+    public int Balance { get { return TotalPoints - PointsClaimed; } set { _ = value; } }
 
     public void Mapping(Profile profile)
     {
@@ -35,17 +37,9 @@ public class LeaderboardUserDto : IMapFrom<User>
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.FullName))
                 .ForMember(dst => dst.ProfilePic, opt => opt.MapFrom(src => src.Avatar))
                 .ForMember(dst => dst.Rank, opt => opt.Ignore())
-                .ForMember(dst => dst.TotalPoints, opt => opt.MapFrom(src => src.UserAchievements
-                                                                                    .Sum(ua => ua.Achievement.Value)))
-                .ForMember(dst => dst.Balance, opt => {
-                    opt.PreCondition(src => src.UserRewards.Any());
-                    opt.MapFrom(src => src.UserAchievements.Sum(ua => ua.Achievement.Value)
-                                       - src.UserRewards.Sum(ur => ur.Reward.Cost));
-                })
-                .ForMember(dst => dst.Balance, opt => {
-                    opt.PreCondition(src => !src.UserRewards.Any());
-                    opt.MapFrom(src => src.UserAchievements.Sum(ua => ua.Achievement.Value));
-                })
+                .ForMember(dst => dst.TotalPoints, opt => opt.MapFrom(src => src.UserAchievements.Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsClaimed, opt => opt.MapFrom(src => src.UserRewards.Sum(ur => ur.Reward.Cost)))
+
                 // TODO:    Using DateTime.Now here presents instability for testing the queries dependent
                 //          on this DTO. As discussed with williamliebenberg@ssw.com.au, we will accept
                 //          this tech debt for now and investigate a better approach in the future. See

--- a/src/SSW.Rewards.Application/Leaderboard/Queries/Common/LeaderboardUserDto.cs
+++ b/src/SSW.Rewards.Application/Leaderboard/Queries/Common/LeaderboardUserDto.cs
@@ -1,4 +1,5 @@
-﻿using SSW.Rewards.Application.Common.Mappings;
+﻿using SSW.Rewards.Application.Common.Extensions;
+using SSW.Rewards.Application.Common.Mappings;
 
 namespace SSW.Rewards.Application.Leaderboard.Queries.Common;
 
@@ -16,12 +17,19 @@ public class LeaderboardUserDto : IMapFrom<User>
 
     public int Balance { get; set; }
 
+    public int PointsToday { get; set; }
+
+    public int PointsThisWeek { get; set; }
+
     public int PointsThisMonth { get; set; }
 
     public int PointsThisYear { get; set; }
 
     public void Mapping(Profile profile)
     {
+        var start = DateTime.Now.FirstDayOfWeek();
+        var end = DateTime.Now.FirstDayOfWeek().AddDays(-7);
+
         profile.CreateMap<User, LeaderboardUserDto>()
                 .ForMember(dst => dst.UserId, opt => opt.MapFrom(src => src.Id))
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.FullName))
@@ -47,6 +55,12 @@ public class LeaderboardUserDto : IMapFrom<User>
                                                                                     .Sum(ua => ua.Achievement.Value)))
                 .ForMember(dst => dst.PointsThisMonth, opt => opt.MapFrom(src => src.UserAchievements
                                                                                     .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year && ua.AwardedAt.Month == DateTime.Now.Month)
+                                                                                    .Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsToday, opt => opt.MapFrom(src => src.UserAchievements
+                                                                                    .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year && ua.AwardedAt.Month == DateTime.Now.Month && ua.AwardedAt.Day == DateTime.Now.Day)
+                                                                                    .Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsThisWeek, opt => opt.MapFrom(src => src.UserAchievements
+                                                                                    .Where(ua => start <= ua.AwardedAt && ua.AwardedAt <= end)
                                                                                     .Sum(ua => ua.Achievement.Value)));
     }
 }

--- a/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardList.cs
+++ b/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardList.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper.QueryableExtensions;
+using SSW.Rewards.Application.Common.Extensions;
 using SSW.Rewards.Application.Leaderboard.Queries.Common;
 
 namespace SSW.Rewards.Application.Leaderboard.Queries.GetFilteredLeaderboardList;
@@ -37,9 +38,20 @@ public class GetFilteredLeaderboardListHandler : IRequestHandler<GetFilteredLead
         {
             query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year));
         }
-        else if (request.Filter == LeaderboardFilter.ThisMonth) // and year
+        else if (request.Filter == LeaderboardFilter.ThisMonth) 
         {
-            query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Month == _dateTime.Now.Month));
+            query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year && a.AwardedAt.Month == _dateTime.Now.Month));
+        }
+        else if (request.Filter == LeaderboardFilter.Today)
+        {
+            query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year && a.AwardedAt.Month == _dateTime.Now.Month && a.AwardedAt.Day == _dateTime.Now.Day));
+        }
+        else if (request.Filter == LeaderboardFilter.ThisWeek)
+        {
+            var start = DateTime.Now.FirstDayOfWeek();
+            var end = DateTime.Now.FirstDayOfWeek().AddDays(-7);
+            // TODO: Find a better way - EF Can't translate our extension method -- so writing the date range comparison directly in linq for now
+            query = query.Where(u => u.UserAchievements.Any(a => start <= a.AwardedAt && a.AwardedAt <= end));
         }
 
         var users = await query.Include(u => u.UserAchievements)

--- a/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardListQuery.cs
+++ b/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardListQuery.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper.QueryableExtensions;
+using SSW.Rewards.Application.Common.Extensions;
 using SSW.Rewards.Application.Leaderboard.Queries.Common;
 
 namespace SSW.Rewards.Application.Leaderboard.Queries.GetFilteredLeaderboardList;
@@ -35,7 +36,18 @@ public class GetFilteredLeaderboardListQueryHandler : IRequestHandler<GetFiltere
         }
         else if (request.Filter == LeaderboardFilter.ThisMonth)
         {
-            query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Month == _dateTime.Now.Month && a.AwardedAt.Year == _dateTime.Now.Year));
+            query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year && a.AwardedAt.Month == _dateTime.Now.Month));
+        }
+        else if (request.Filter == LeaderboardFilter.Today)
+        {
+            query = query.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year && a.AwardedAt.Month == _dateTime.Now.Month && a.AwardedAt.Day == _dateTime.Now.Day));
+        }
+        else if (request.Filter == LeaderboardFilter.ThisWeek)
+        {
+            var start = DateTime.Now.FirstDayOfWeek();
+            var end = DateTime.Now.FirstDayOfWeek().AddDays(-7);
+            // TODO: Find a better way - EF Can't translate our extension method -- so writing the date range comparison directly in linq for now
+            query = query.Where(u => u.UserAchievements.Any(a => start <= a.AwardedAt && a.AwardedAt <= end));
         }
 
         var users = await query.Include(u => u.UserAchievements)
@@ -58,10 +70,4 @@ public class GetFilteredLeaderboardListQueryHandler : IRequestHandler<GetFiltere
 
         return model;
     }
-}
-
-public enum LeaderboardFilter
-{
-    ThisMonth,
-    ThisYear
 }

--- a/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardListValidator.cs
+++ b/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredLeaderboardListValidator.cs
@@ -10,9 +10,11 @@ public class GetFilteredLeaderboardListValidator : AbstractValidator<GetFiltered
 
     public bool BeValidFilter(LeaderboardFilter filter)
     {
-        if (filter == LeaderboardFilter.ThisMonth || filter == LeaderboardFilter.ThisYear)
-            return true;
-
-        return false;
+        return
+            filter == LeaderboardFilter.ThisMonth ||
+            filter == LeaderboardFilter.ThisYear ||
+            filter == LeaderboardFilter.ThisWeek ||
+            filter == LeaderboardFilter.Today ||
+            filter == LeaderboardFilter.Forever;
     }
 }

--- a/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredListQueryValidator.cs
+++ b/src/SSW.Rewards.Application/Leaderboard/Queries/GetFilteredLeaderboardList/GetFilteredListQueryValidator.cs
@@ -10,9 +10,11 @@ public class GetFilteredListQueryValidator : AbstractValidator<GetFilteredLeader
 
     public bool BeValidFilter(LeaderboardFilter filter)
     {
-        if (filter == LeaderboardFilter.ThisMonth || filter == LeaderboardFilter.ThisYear)
-            return true;
-
-        return false;
+        return 
+            filter == LeaderboardFilter.ThisMonth || 
+            filter == LeaderboardFilter.ThisYear ||
+            filter == LeaderboardFilter.ThisWeek ||
+            filter == LeaderboardFilter.Today ||
+            filter == LeaderboardFilter.Forever;
     }
 }

--- a/src/SSW.Rewards.Application/PrizeDraw/Queries/GetEligibleUsers.cs
+++ b/src/SSW.Rewards.Application/PrizeDraw/Queries/GetEligibleUsers.cs
@@ -1,0 +1,183 @@
+﻿using System.Security.Cryptography;
+using AutoMapper.QueryableExtensions;
+using SSW.Rewards.Application.Common.Exceptions;
+using SSW.Rewards.Application.Common.Extensions;
+using SSW.Rewards.Application.Common.Mappings;
+using SSW.Rewards.Application.Leaderboard.Queries.GetFilteredLeaderboardList;
+using SSW.Rewards.Application.Rewards.Commands.UpdateReward;
+
+namespace SSW.Rewards.Application.PrizeDraw.Queries;
+
+public class EligibleUserViewModel : IMapFrom<User>
+{
+    public int? UserId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Email { get; set; }
+
+    public int TotalPoints { get; set; }
+
+    public int PointsClaimed { get; set; }
+
+    public int PointsToday { get; set; }
+    public int PointsThisWeek { get; set; }
+
+    public int PointsThisMonth { get; set; }
+
+    public int PointsThisYear { get; set; }
+
+    public int Balance { get { return TotalPoints - PointsClaimed; } set { _ = value; } }
+
+    public void Mapping(Profile profile)
+    {
+        var start = DateTime.Now.FirstDayOfWeek();
+        var end = DateTime.Now.FirstDayOfWeek().AddDays(-7);
+
+        profile.CreateMap<User, EligibleUserViewModel>()
+                .ForMember(dst => dst.UserId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.FullName))
+                .ForMember(dst => dst.Email, opt => opt.MapFrom(src => src.Email))
+                .ForMember(dst => dst.TotalPoints, opt => opt.MapFrom(src => src.UserAchievements.Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsClaimed, opt => opt.MapFrom(src => src.UserRewards.Sum(ur => ur.Reward.Cost)))
+
+                // TODO:    Using DateTime.Now here presents instability for testing the queries dependent
+                //          on this DTO. As discussed with williamliebenberg@ssw.com.au, we will accept
+                //          this tech debt for now and investigate a better approach in the future. See
+                //          https://github.com/SSWConsulting/SSW.Rewards.API/issues/7
+                .ForMember(dst => dst.PointsThisYear, opt => opt.MapFrom(src => src.UserAchievements
+                    .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year)
+                    .Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsThisMonth, opt => opt.MapFrom(src => src.UserAchievements
+                    .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year && ua.AwardedAt.Month == DateTime.Now.Month)
+                    .Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsToday, opt => opt.MapFrom(src => src.UserAchievements
+                    .Where(ua => ua.AwardedAt.Year == DateTime.Now.Year && ua.AwardedAt.Month == DateTime.Now.Month && ua.AwardedAt.Day == DateTime.Now.Day)
+                    .Sum(ua => ua.Achievement.Value)))
+                .ForMember(dst => dst.PointsThisWeek, opt => opt.MapFrom(src => src.UserAchievements
+                    .Where(ua => start <= ua.AwardedAt && ua.AwardedAt <= end)
+                    .Sum(ua => ua.Achievement.Value)));
+    }
+}
+
+public class EligibleUsersViewModel
+{
+    public int RewardId { get; set; }
+    public string? RewardCode { get; set; }
+    public IEnumerable<EligibleUserViewModel> EligibleUsers { get; set; } = new List<EligibleUserViewModel>();
+}
+
+public class GetEligibleUsers : IRequest<EligibleUsersViewModel>
+{
+    public int RewardId { get; set; }
+    public LeaderboardFilter Filter { get; set; }
+    public bool BalanceRequired { get; set; }
+    public bool FilterStaff { get; set; }
+}
+
+public class GetEligibleUsersValidator : AbstractValidator<GetEligibleUsers>
+{
+    public GetEligibleUsersValidator()
+    {
+        RuleFor(r => r.RewardId)
+            .Must(r => r > 0);
+
+        //RuleFor(r => r.Filter)
+        //    .Must(BeValidFilter)
+        //    .WithMessage("Invalid filter");
+    }
+
+    //public bool BeValidFilter(LeaderboardFilter filter)
+    //{
+    //    return 
+    //        filter == LeaderboardFilter.Forever || 
+    //        filter == LeaderboardFilter.Today ||
+    //        filter == LeaderboardFilter.ThisMonth ||
+    //        filter == LeaderboardFilter.ThisYear;
+    //}
+}
+
+public class GetEligibleUsersHandler : IRequestHandler<GetEligibleUsers, EligibleUsersViewModel>
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IMapper _mapper;
+    private readonly IDateTime _dateTime;
+
+    public GetEligibleUsersHandler(
+        IApplicationDbContext context,
+        IMapper mapper,
+        IDateTime dateTime)
+    {
+        _context = context;
+        _mapper = mapper;
+        _dateTime = dateTime;
+    }
+
+    public async Task<EligibleUsersViewModel> Handle(GetEligibleUsers request, CancellationToken cancellationToken)
+    {
+        var reward = await _context.Rewards.FirstOrDefaultAsync(r => r.Id == request.RewardId, cancellationToken);
+        if (reward == null)
+        {
+            throw new NotFoundException(nameof(UpdateRewardCommand), request.RewardId);
+        }
+
+        // find all the activated users with enough points in the (today/month/year/forever) leaderboard to claim the specific reward 
+        var eligibleUsers = _context.Users.Where(u => u.Activated == true);
+
+        if (request.Filter == LeaderboardFilter.ThisYear)
+        {
+            eligibleUsers = eligibleUsers.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year));
+        }
+        else if (request.Filter == LeaderboardFilter.ThisMonth)
+        {
+            eligibleUsers = eligibleUsers.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year && a.AwardedAt.Month == _dateTime.Now.Month));
+        }
+        else if (request.Filter == LeaderboardFilter.Today)
+        {
+            eligibleUsers = eligibleUsers.Where(u => u.UserAchievements.Any(a => a.AwardedAt.Year == _dateTime.Now.Year && a.AwardedAt.Month == _dateTime.Now.Month && a.AwardedAt.Day == _dateTime.Now.Day));
+        }
+        else if (request.Filter == LeaderboardFilter.ThisWeek)
+        {
+            var start = DateTime.Now.FirstDayOfWeek();
+            var end = DateTime.Now.FirstDayOfWeek().AddDays(-7);
+            // TODO: Find a better way - EF Can't translate our extension method -- so writing the date range comparison directly in linq for now
+            eligibleUsers = eligibleUsers.Where(u => u.UserAchievements.Any(a => start <= a.AwardedAt && a.AwardedAt <= end ));
+        }
+        else if (request.Filter == LeaderboardFilter.Forever)
+        {
+            // no action
+        }
+
+        eligibleUsers = eligibleUsers
+            .Include(u => u.UserRewards).ThenInclude(ur => ur.Reward)
+            .Include(u => u.UserAchievements).ThenInclude(u => u.Achievement);
+
+        if(request.BalanceRequired)
+        {
+            eligibleUsers = eligibleUsers.Where(u =>
+                // Eligible = (Total Points - Points already Claimed):RemainingPoints >= Reward.Cost
+                (u.UserAchievements.Sum(ua => ua.Achievement.Value) - u.UserRewards.Sum(ur => ur.Reward.Cost)) >= reward.Cost);
+        }
+        
+        var users = await eligibleUsers
+            .ProjectTo<EligibleUserViewModel>(_mapper.ConfigurationProvider)
+            .ToListAsync(cancellationToken);
+
+        // filter out any @ssw.com.au users (.ends with didn't translate with EF Core :(
+        if (request.FilterStaff)
+        {
+            users = users.Where(u => (u.Email != null && !u.Email.EndsWith("@ssw.com.au", StringComparison.OrdinalIgnoreCase))).ToList();
+        }
+
+        EligibleUsersViewModel vm = new()
+        {
+            RewardId = request.RewardId,
+            RewardCode = reward.Code,
+            EligibleUsers = users
+        };
+
+        vm.EligibleUsers = vm.EligibleUsers.OrderByDescending(u => u.Balance);
+
+        return vm;
+    }
+}

--- a/src/SSW.Rewards.Application/Rewards/Commands/ClaimReward/ClaimRewardCommand.cs
+++ b/src/SSW.Rewards.Application/Rewards/Commands/ClaimReward/ClaimRewardCommand.cs
@@ -66,10 +66,14 @@ public class ClaimRewardCommandHandler : IRequestHandler<ClaimRewardCommand, Cla
             };
         }
 
+        // award the user an achievement for claiming their first prize
         if (!user.UserRewards.Any())
         {
             var achievement = await _context.Achievements.FirstOrDefaultAsync(a => a.Name == MilestoneAchievements.ClaimPrize, cancellationToken);
-            user.UserAchievements.Add(new UserAchievement { Achievement = achievement });
+            if (achievement != null)
+            {
+                user.UserAchievements.Add(new UserAchievement { Achievement = achievement });
+            }
         }
 
         user.UserRewards.Add(new UserReward

--- a/src/SSW.Rewards.Application/SSW.Rewards.Application.csproj
+++ b/src/SSW.Rewards.Application/SSW.Rewards.Application.csproj
@@ -24,4 +24,8 @@
         <ProjectReference Include="..\SSW.Rewards.Domain\SSW.Rewards.Domain.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="PrizeDraw\Commands\" />
+    </ItemGroup>
+
 </Project>

--- a/src/SSW.Rewards.Application/Users/Queries/GetCurrentUserRoles/GetCurrentUserRolesQuery.cs
+++ b/src/SSW.Rewards.Application/Users/Queries/GetCurrentUserRoles/GetCurrentUserRolesQuery.cs
@@ -18,6 +18,6 @@ public class GetCurrentUserRolesQuerHandler : IRequestHandler<GetCurrentUserRole
     {
         var roles = await _userService.GetCurrentUserRoles(cancellationToken);
 
-        return roles.Select(r => r.Name).ToArray();
+        return roles?.Select(r => r.Name ?? "").ToArray() ?? Array.Empty<string>();
     }
 }

--- a/src/SSW.Rewards.Domain/Entities/UserReward.cs
+++ b/src/SSW.Rewards.Domain/Entities/UserReward.cs
@@ -4,6 +4,6 @@ public class UserReward : BaseEntity
     public int UserId { get; set; }
     public User User { get; set; } = new();
     public int RewardId { get; set; }
-    public Reward Reward { get; set; } = new();
+    public Reward Reward { get; set; } = null!;
     public DateTime AwardedAt { get; set; }
 }

--- a/src/SSW.Rewards.Domain/Enums/LeaderboardFilter.cs
+++ b/src/SSW.Rewards.Domain/Enums/LeaderboardFilter.cs
@@ -1,5 +1,8 @@
 ﻿public enum LeaderboardFilter
 {
     ThisMonth,
-    ThisYear
+    ThisYear,
+    ThisWeek,
+    Today,
+    Forever
 }

--- a/src/SSW.Rewards.Infrastructure/ConfigureServices.cs
+++ b/src/SSW.Rewards.Infrastructure/ConfigureServices.cs
@@ -17,8 +17,13 @@ public static class ConfigureServices
         services.AddScoped<AuditableEntitySaveChangesInterceptor>();
 
         services.AddDbContext<ApplicationDbContext>(options =>
-                options.UseSqlServer(configuration.GetConnectionString("DefaultConnection"),
-                    builder => builder.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName)));
+        {
+#if DEBUG
+            options.EnableSensitiveDataLogging();
+#endif
+            options.UseSqlServer(configuration.GetConnectionString("DefaultConnection"),
+                builder => builder.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName));
+        });
 
         services.AddScoped<IApplicationDbContext>(provider => provider.GetRequiredService<ApplicationDbContext>());
 

--- a/src/WebUI/ClientApp/src/app/web-api-client.ts
+++ b/src/WebUI/ClientApp/src/app/web-api-client.ts
@@ -3423,11 +3423,12 @@ export class LeaderboardUserDto implements ILeaderboardUserDto {
     name?: string | undefined;
     profilePic?: string | undefined;
     totalPoints?: number;
-    balance?: number;
+    pointsClaimed?: number;
     pointsToday?: number;
     pointsThisWeek?: number;
     pointsThisMonth?: number;
     pointsThisYear?: number;
+    balance?: number;
 
     constructor(data?: ILeaderboardUserDto) {
         if (data) {
@@ -3445,11 +3446,12 @@ export class LeaderboardUserDto implements ILeaderboardUserDto {
             this.name = _data["name"];
             this.profilePic = _data["profilePic"];
             this.totalPoints = _data["totalPoints"];
-            this.balance = _data["balance"];
+            this.pointsClaimed = _data["pointsClaimed"];
             this.pointsToday = _data["pointsToday"];
             this.pointsThisWeek = _data["pointsThisWeek"];
             this.pointsThisMonth = _data["pointsThisMonth"];
             this.pointsThisYear = _data["pointsThisYear"];
+            this.balance = _data["balance"];
         }
     }
 
@@ -3467,11 +3469,12 @@ export class LeaderboardUserDto implements ILeaderboardUserDto {
         data["name"] = this.name;
         data["profilePic"] = this.profilePic;
         data["totalPoints"] = this.totalPoints;
-        data["balance"] = this.balance;
+        data["pointsClaimed"] = this.pointsClaimed;
         data["pointsToday"] = this.pointsToday;
         data["pointsThisWeek"] = this.pointsThisWeek;
         data["pointsThisMonth"] = this.pointsThisMonth;
         data["pointsThisYear"] = this.pointsThisYear;
+        data["balance"] = this.balance;
         return data;
     }
 }
@@ -3482,11 +3485,12 @@ export interface ILeaderboardUserDto {
     name?: string | undefined;
     profilePic?: string | undefined;
     totalPoints?: number;
-    balance?: number;
+    pointsClaimed?: number;
     pointsToday?: number;
     pointsThisWeek?: number;
     pointsThisMonth?: number;
     pointsThisYear?: number;
+    balance?: number;
 }
 
 export class EligibleUsersViewModel implements IEligibleUsersViewModel {

--- a/src/WebUI/Controllers/LeaderboardController.cs
+++ b/src/WebUI/Controllers/LeaderboardController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using SSW.Rewards.Application.Leaderboard.Queries.Common;
 using SSW.Rewards.Application.Leaderboard.Queries.GetLeaderboardList;
+using SSW.Rewards.Application.PrizeDraw.Queries;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace SSW.Rewards.WebAPI.Controllers;
 
@@ -9,14 +11,18 @@ public class LeaderboardController : ApiControllerBase
     [HttpGet]
     public async Task<ActionResult<LeaderboardListViewModel>> Get()
     {
-		try
-		{
-			return Ok(await Mediator.Send(new GetLeaderboardListQuery()));
-		}
-		catch (Exception ex)
-		{
+        return Ok(await Mediator.Send(new GetLeaderboardListQuery()));
+    }
 
-			throw;
-		}
+    [HttpGet]
+    public async Task<ActionResult<EligibleUsersViewModel>> GetEligibleUsers(int rewardId, LeaderboardFilter filter, bool balanceRequired, bool filterStaff)
+    {
+        return Ok(await Mediator.Send(new GetEligibleUsers() 
+        {
+            RewardId = rewardId, 
+            Filter = filter,
+            BalanceRequired = balanceRequired,
+            FilterStaff = filterStaff
+        }));
     }
 }

--- a/src/WebUI/appsettings.Development.json
+++ b/src/WebUI/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=.;Database=SSWRewards;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "<check in secrets.json>"
   },
   "Logging": {
     "LogLevel": {
@@ -9,7 +9,27 @@
       "Microsoft": "Information"
     }
   },
+
   "CloudBlobProviderOptions": {
-    "ContentStorageConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
-  }
+    "ContentStorageConnectionString": "<check in secrets.json>"
+  },
+
+  "UseInMemoryDatabase": false,
+  
+  "EmailUser": "<check in secrets.json>",
+  "EmailPassword": "<check in secrets.json>",
+
+  "SMTPSettings": {
+    "DefaultSender": "info@ssw.com.au",
+    "DefaultSenderName": "SSW",
+    "Host": "ssw-com-au.mail.protection.outlook.com",
+    "Port": "25"
+  },
+
+  "SendGridAPIKey": "<check in secrets.json>",
+    
+  //"SigningAuthority": "https://ids.goforgoldman.com",
+  //"SigningAuthority": "https://sswidentity-stage.azurewebsites.net"
+  //"SigningAuthority": "https://identity.ssw.com.au"
+  "SigningAuthority": "https://localhost:5003"
 }

--- a/src/WebUI/appsettings.json
+++ b/src/WebUI/appsettings.json
@@ -20,29 +20,5 @@
   },
   "CloudBlobProviderOptions": {
     "ContentStorageConnectionString": "<Add your blob storage connection string>"
-  },
-  "Serilog": {
-    "WriteTo": [
-      {
-        "Name": "ApplicationInsights",
-        "Args": {
-          "restrictedToMinimumLevel": "Information",
-          "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-        }
-      },
-      {
-        "Name": "Async",
-        "Args": {
-          "configure": [
-            {
-              "Name": "Console",
-              "Args": {
-                "restrictedToMinimumLevel": "Verbose"
-              }
-            }
-          ]
-        }
-      }
-    ]
-  }
+  }  
 }

--- a/src/WebUI/wwwroot/api/specification.json
+++ b/src/WebUI/wwwroot/api/specification.json
@@ -342,6 +342,66 @@
         ]
       }
     },
+    "/api/Leaderboard/GetEligibleUsers": {
+      "get": {
+        "tags": [
+          "Leaderboard"
+        ],
+        "operationId": "Leaderboard_GetEligibleUsers",
+        "parameters": [
+          {
+            "name": "rewardId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/LeaderboardFilter"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "balanceRequired",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "filterStaff",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EligibleUsersViewModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT": []
+          }
+        ]
+      }
+    },
     "/api/Notifications/List": {
       "get": {
         "tags": [
@@ -2023,6 +2083,14 @@
             "type": "integer",
             "format": "int32"
           },
+          "pointsToday": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pointsThisWeek": {
+            "type": "integer",
+            "format": "int32"
+          },
           "pointsThisMonth": {
             "type": "integer",
             "format": "int32"
@@ -2032,6 +2100,91 @@
             "format": "int32"
           }
         }
+      },
+      "EligibleUsersViewModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "rewardId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rewardCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "eligibleUsers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EligibleUserViewModel"
+            }
+          }
+        }
+      },
+      "EligibleUserViewModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "userId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalPoints": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pointsClaimed": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pointsToday": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pointsThisWeek": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pointsThisMonth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pointsThisYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "balance": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "LeaderboardFilter": {
+        "type": "integer",
+        "description": "",
+        "x-enumNames": [
+          "ThisMonth",
+          "ThisYear",
+          "ThisWeek",
+          "Today",
+          "Forever"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
       },
       "NotificationHistoryListViewModel": {
         "type": "object",

--- a/src/WebUI/wwwroot/api/specification.json
+++ b/src/WebUI/wwwroot/api/specification.json
@@ -2079,7 +2079,7 @@
             "type": "integer",
             "format": "int32"
           },
-          "balance": {
+          "pointsClaimed": {
             "type": "integer",
             "format": "int32"
           },
@@ -2096,6 +2096,10 @@
             "format": "int32"
           },
           "pointsThisYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "balance": {
             "type": "integer",
             "format": "int32"
           }


### PR DESCRIPTION
Add - GetEligibleUsers request, handler and endpoint
Add - Forever, PointsThisWeek and PointsToday to LeaderboardFilter
Add - PointsToday and PointsThisWeek to LeaderboardUserDto
Fix - UserReward entity shouldn't auto initialize related Reward entities
Fix - GetCurrentUserRolesQuery can throw NullReferenceException
Fix - UserService throws NRE in various situations when users or roles aren't available
Fix - ClaumRewardForUserCommand throws NRE when user is missing
Remove - Achievements can now have values > 1000
Fix - Balance calculation for LeaderboardUserDto is now correct
Add - PointsClaimed in LeaderboardUserDto