### PR TITLE
Get rid of 'new()' in Domain

### DIFF
--- a/src/SSW.Rewards.Domain/Entities/Quiz.cs
+++ b/src/SSW.Rewards.Domain/Entities/Quiz.cs
@@ -10,6 +10,6 @@ public class Quiz : BaseEntity
     public virtual Achievement Achievement { get; set; }
     public ICollection<QuizQuestion> Questions { get; set; } = new HashSet<QuizQuestion>();
     public ICollection<CompletedQuiz> CompletedQuizzes { get; set; } = new HashSet<CompletedQuiz>();
-    public User? CreatedBy { get; set; } = new();
+    public User CreatedBy { get; set; } = null!;
     public int? CreatedById { get; set; }
 }

--- a/src/SSW.Rewards.Domain/Entities/QuizQuestion.cs
+++ b/src/SSW.Rewards.Domain/Entities/QuizQuestion.cs
@@ -2,7 +2,7 @@
 public class QuizQuestion : BaseEntity
 {
     public int QuizId { get; set; }
-    public virtual Quiz Quiz { get; set; } = new();
+    public virtual Quiz Quiz { get; set; } = null!;
     public string? Text { get; set; } = string.Empty;
     public virtual ICollection<QuizAnswer> Answers { get; set; } = new HashSet<QuizAnswer>();
 }

--- a/src/SSW.Rewards.Domain/Entities/Reward.cs
+++ b/src/SSW.Rewards.Domain/Entities/Reward.cs
@@ -5,7 +5,7 @@ public class Reward : BaseEntity
     public string? Name { get; set; } = string.Empty;
     public int Cost { get; set; }
     public string? ImageUri { get; set; } = string.Empty;
-    public RewardType RewardType { get; set; } = new();
+    public RewardType RewardType { get; set; } = RewardType.Digital;
     public Icons Icon { get; set; }
     public bool IconIsBranded { get; set; }
     public bool IsOnboardingReward { get; set; }

--- a/src/SSW.Rewards.Domain/Entities/SocialMediaPlatform.cs
+++ b/src/SSW.Rewards.Domain/Entities/SocialMediaPlatform.cs
@@ -4,5 +4,5 @@ public class SocialMediaPlatform : BaseEntity
     public string Name { get; set; } = string.Empty;
     public ICollection<UserSocialMediaId> UserSocialMediaIds { get; set; } = new HashSet<UserSocialMediaId>();
     public int AchievementId { get; set; }
-    public Achievement Achievement { get; set; } = new();
+    public Achievement Achievement { get; set; } = null!;
 }

--- a/src/SSW.Rewards.Domain/Entities/StaffMemberSkill.cs
+++ b/src/SSW.Rewards.Domain/Entities/StaffMemberSkill.cs
@@ -2,8 +2,8 @@
 public class StaffMemberSkill : BaseEntity
 {
     public int SkillId { get; set; }
-    public Skill Skill { get; set; } = new();
+    public Skill Skill { get; set; } = null!;
     public int StaffMemberId { get; set; }
-    public StaffMember StaffMember { get; set; } = new();
+    public StaffMember StaffMember { get; set; } = null!;
     public SkillLevel Level { get; set; }
 }

--- a/src/SSW.Rewards.Domain/Entities/User.cs
+++ b/src/SSW.Rewards.Domain/Entities/User.cs
@@ -4,7 +4,7 @@ public class User : BaseEntity
     public string? FullName { get; set; } = string.Empty;
     public string? Email { get; set; } = string.Empty;
     public string? Avatar { get; set; } = string.Empty;
-    public PostalAddress Address { get; set; } = new();
+    public PostalAddress? Address { get; set; }
     public int? AddressId { get; set; }
     public bool Activated { get; set; }
     public ICollection<UserAchievement> UserAchievements { get; set; } = new HashSet<UserAchievement>();

--- a/src/SSW.Rewards.Domain/Entities/UserReward.cs
+++ b/src/SSW.Rewards.Domain/Entities/UserReward.cs
@@ -2,7 +2,7 @@
 public class UserReward : BaseEntity
 {
     public int UserId { get; set; }
-    public User User { get; set; } = new();
+    public User User { get; set; } = null!;
     public int RewardId { get; set; }
     public Reward Reward { get; set; } = null!;
     public DateTime AwardedAt { get; set; }

--- a/src/SSW.Rewards.Domain/Entities/UserRole.cs
+++ b/src/SSW.Rewards.Domain/Entities/UserRole.cs
@@ -2,7 +2,7 @@
 public class UserRole : BaseEntity
 {
     public int UserId { get; set; }
-    public User User { get; set; } = new();
+    public User User { get; set; } = null!;
     public int RoleId { get; set; }
-    public Role Role { get; set; } = new();
+    public Role Role { get; set; } = null!;
 }


### PR DESCRIPTION
Instances of `= new()` on navigation properties in the Domain project is causing blank records to be inserted into the DB. This is here to address compiler warning CS8618 due to nullable reference types meaning the property should be initialised.

However, in every case in the Domain, these will either never be null (in the case of navigation properties, as guaranteed by entity framework, see: https://learn.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types), should have a default value (in the case of the `RewardType` enum), or should in fact be nullable (as in the case of the `PostalAddress`).

This PR addresses this issue. Data cleanup is still required in the database.

Fixes #41 