### PR TITLE
🐛 Fix CORS issue

### DIFF
--- a/src/WebUI/Program.cs
+++ b/src/WebUI/Program.cs
@@ -42,6 +42,9 @@ app.UseSwaggerUi3(settings =>
 
 app.UseRouting();
 
+string _allowSpecificOrigins = "_AllowSpecificOrigins";
+app.UseCors(_allowSpecificOrigins);
+    
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -52,9 +55,5 @@ app.MapControllerRoute(
 //app.MapRazorPages();
 
 //app.MapFallbackToFile("index.html"); ;
-
-string _allowSpecificOrigins = "_AllowSpecificOrigins";
-
-app.UseCors(_allowSpecificOrigins);
 
 app.Run();


### PR DESCRIPTION
From the Doc: `UseCors` must be placed after `UseRouting` and before `UseAuthorization`. This is to ensure that CORS headers are included in the response for both authorized and unauthorized calls. (https://learn.microsoft.com/en-us/aspnet/core/security/cors?view=aspnetcore-7.0)