### PR TITLE
Add profile deletion endpoint

### DIFF
--- a/.github/workflows/az-deploy.yml
+++ b/.github/workflows/az-deploy.yml
@@ -28,7 +28,11 @@ on:
         required: true
       SQL_ADMIN_GROUP_SID:
         required: true
-      SENDGRID_KEY:
+      GRAPH_TENANT_ID:
+        required: true
+      GRAPH_CLIENT_ID:
+        required: true
+      GRAPH_CLIENT_SECRET:
         required: true
 
 
@@ -56,7 +60,9 @@ jobs:
       env:
         sqlAdminGroup: ${{ secrets.SQL_ADMIN_GROUP }}
         sqlAdminSid: ${{ secrets.SQL_ADMIN_GROUP_SID }}
-        sendGridKey: ${{ secrets.SENDGRID_KEY }}
+        graphTenantId: ${{ secrets.GRAPH_TENANT_ID }}
+        graphClientId: ${{ secrets.GRAPH_CLIENT_ID }}
+        graphClientSecret: ${{ secrets.GRAPH_CLIENT_SECRET }}
       run: | 
         $out = az deployment group create `
           --resource-group ${{ inputs.RESOURCE_GROUP }} `
@@ -66,7 +72,9 @@ jobs:
             appServicePlanResourceGroup=${{ inputs.APP_SERVICE_PLAN_RESOURCE_GROUP }} `
             sqlAdministratorsLoginName=$env:sqlAdminGroup `
             sqlAdministratorsObjectId=$env:sqlAdminSid `
-            sendGridKey=$env:sendGridKey `
+            graphTenantId=$env:graphTenantId `
+            graphClientId=$env:graphClientId `
+            graphClientSecret=$env:graphClientSecret `
             adminPortalUrl=${{ inputs.ADMIN_PORTAL_URL }} `
             idsUrl=${{ inputs.IDS_URL }} `
             | convertfrom-json | foreach properties | foreach outputs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
       SQL_ADMIN_GROUP_SID: ${{ secrets.SQL_ADMIN_GROUP_SID }}
-      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
+      GRAPH_TENANT_ID: ${{ secrets.GRAPH_TENANT_ID }}
+      GRAPH_CLIENT_ID: ${{ secrets.GRAPH_CLIENT_ID }}
+      GRAPH_CLIENT_SECRET: ${{ secrets.GRAPH_CLIENT_SECRET }}
 
   deploy_staging:
     needs: deploy_dev
@@ -42,7 +44,9 @@ jobs:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
       SQL_ADMIN_GROUP_SID: ${{ secrets.SQL_ADMIN_GROUP_SID }}
-      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
+      GRAPH_TENANT_ID: ${{ secrets.GRAPH_TENANT_ID }}
+      GRAPH_CLIENT_ID: ${{ secrets.GRAPH_CLIENT_ID }}
+      GRAPH_CLIENT_SECRET: ${{ secrets.GRAPH_CLIENT_SECRET }}
 
   deploy_prod:
     needs: deploy_staging
@@ -59,4 +63,6 @@ jobs:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       SQL_ADMIN_GROUP: ${{ secrets.SQL_ADMIN_GROUP }}
       SQL_ADMIN_GROUP_SID: ${{ secrets.SQL_ADMIN_GROUP_SID }}
-      SENDGRID_KEY: ${{ secrets.SENDGRID_KEY }}
+      GRAPH_TENANT_ID: ${{ secrets.GRAPH_TENANT_ID }}
+      GRAPH_CLIENT_ID: ${{ secrets.GRAPH_CLIENT_ID }}
+      GRAPH_CLIENT_SECRET: ${{ secrets.GRAPH_CLIENT_SECRET }}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestMinor"
+    "version": "7.0.100",
+    "rollForward": "latestMajor"
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,7 +18,12 @@ param sqlAdministratorsObjectId string
 param adminPortalUrl string
 param idsUrl string
 
-param sendGridKey string
+@secure()
+param graphClientId string
+@secure()
+param graphClientSecret string
+@secure()
+param graphTenantId string
 
 @secure()
 @description('Specifies secrets to connect to apple https://docs.microsoft.com/en-us/azure/templates/microsoft.notificationhubs/namespaces/notificationhubs?tabs=bicep#apnscredentialproperties Sample: {"keyId":"key id","appName":"bundle id","appId":"team id","token":"token"}')
@@ -67,7 +72,9 @@ module appService 'modules/webapp.bicep' = {
     adminPortalUrl: adminPortalUrl
     idsUrl: idsUrl
     now: now
-    sendGridKey: sendGridKey
+    graphClientId: graphClientId
+    graphClientSecret: graphClientSecret
+    graphTenantId: graphTenantId
   }
 }
 

--- a/src/SSW.Rewards.Application/Common/Interfaces/IEmailService.cs
+++ b/src/SSW.Rewards.Application/Common/Interfaces/IEmailService.cs
@@ -5,5 +5,8 @@ namespace SSW.Rewards.Application.Common.Interfaces;
 public interface IEmailService
 {
     Task<bool> SendPhysicalRewardEmail(string to, string toName, string subject, PhysicalRewardEmail emailProps, CancellationToken cancellationToken);
+
     Task<bool> SendDigitalRewardEmail(string to, string toName, string subject, DigitalRewardEmail emailProps, CancellationToken cancellationToken);
+
+    Task<bool> SendProfileDeletionRequest(string toMail, string toName, CancellationToken cancellationToken);
 }

--- a/src/SSW.Rewards.Application/Common/Interfaces/IEmailService.cs
+++ b/src/SSW.Rewards.Application/Common/Interfaces/IEmailService.cs
@@ -1,4 +1,5 @@
 ﻿using SSW.Rewards.Application.Common.Models;
+using SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
 
 namespace SSW.Rewards.Application.Common.Interfaces;
 
@@ -8,5 +9,5 @@ public interface IEmailService
 
     Task<bool> SendDigitalRewardEmail(string to, string toName, string subject, DigitalRewardEmail emailProps, CancellationToken cancellationToken);
 
-    Task<bool> SendProfileDeletionRequest(string toMail, string toName, CancellationToken cancellationToken);
+    Task<bool> SendProfileDeletionRequest(DeleteProfileEmail model, CancellationToken cancellationToken);
 }

--- a/src/SSW.Rewards.Application/Users/Commands/DeleteMyProfile/DeleteMyProfileCommand.cs
+++ b/src/SSW.Rewards.Application/Users/Commands/DeleteMyProfile/DeleteMyProfileCommand.cs
@@ -22,7 +22,16 @@ public class DeleteMyProfileCommandHandler : IRequestHandler<DeleteMyProfileComm
         var userName = _currentUserService.GetUserFullName();
         var userEmail = _currentUserService.GetUserEmail();
 
-        var sent = await _emailService.SendProfileDeletionRequest(userName, userEmail, cancellationToken);
+        var model = new DeleteProfileEmail
+        {
+            UserName = userName,
+            UserEmail = userEmail,
+            // TODO: Technical debt - needs to be switched to an appropriate
+            //       distribution group. See Zendesk ticket #12202.
+            RewardsTeamEmail = "mattgoldman@ssw.com.au",
+        };
+
+        var sent = await _emailService.SendProfileDeletionRequest(model, cancellationToken);
 
         if (sent)
         {

--- a/src/SSW.Rewards.Application/Users/Commands/DeleteMyProfile/DeleteMyProfileCommand.cs
+++ b/src/SSW.Rewards.Application/Users/Commands/DeleteMyProfile/DeleteMyProfileCommand.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
+
+public class DeleteMyProfileCommand : IRequest { }
+
+public class DeleteMyProfileCommandHandler : IRequestHandler<DeleteMyProfileCommand, Unit>
+{
+    private readonly IEmailService _emailService;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<DeleteMyProfileCommandHandler> _logger;
+
+    public DeleteMyProfileCommandHandler(IEmailService emailService, ICurrentUserService currentUserService, ILogger<DeleteMyProfileCommandHandler> logger)
+    {
+        _emailService = emailService;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<Unit> Handle(DeleteMyProfileCommand request, CancellationToken cancellationToken)
+    {
+        var userName = _currentUserService.GetUserFullName();
+        var userEmail = _currentUserService.GetUserEmail();
+
+        var sent = await _emailService.SendProfileDeletionRequest(userName, userEmail, cancellationToken);
+
+        if (sent)
+        {
+            return Unit.Value;
+        }
+        else
+        {
+            _logger.LogError("Could not send profile delete request message for {userName}, {email}", userName, userEmail);
+            throw new Exception($"Failed to send profile delete request message for {userName}, {userEmail}");
+        }
+    }
+}

--- a/src/SSW.Rewards.Application/Users/Commands/DeleteMyProfile/DeleteProfileEmail.cs
+++ b/src/SSW.Rewards.Application/Users/Commands/DeleteMyProfile/DeleteProfileEmail.cs
@@ -1,0 +1,9 @@
+﻿namespace SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
+public class DeleteProfileEmail
+{
+    public string UserName { get; set; }
+
+    public string UserEmail { get; set; }
+
+    public string RewardsTeamEmail { get; set; }
+}

--- a/src/SSW.Rewards.Infrastructure/ConfigureServices.cs
+++ b/src/SSW.Rewards.Infrastructure/ConfigureServices.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using FluentEmail.Graph;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using SSW.Rewards.Application.Common.Interfaces;
@@ -51,11 +52,13 @@ public static class ConfigureServices
 
         configuration.Bind("SMTPSettings", smtpSettings);
 
-        string SendGridAPIKey = configuration.GetValue<string>(nameof(SendGridAPIKey));
+        GraphSenderOptions GraphSenderOptions = new GraphSenderOptions();
 
-        services.AddFluentEmail(smtpSettings.DefaultSender, smtpSettings.DefaultSenderName)
+        configuration.Bind(nameof(GraphSenderOptions), GraphSenderOptions);
+
+        services.AddFluentEmail("verify@ssw.com.au")
                     .AddRazorRenderer()
-                    .AddSendGridSender(SendGridAPIKey);
+                    .AddGraphSender(GraphSenderOptions);
 
         string signingAuthority = configuration.GetValue<string>(nameof(signingAuthority));
 

--- a/src/SSW.Rewards.Infrastructure/Persistence/Migrations/20220809075120_SeedSocialMediaPlatforms.cs
+++ b/src/SSW.Rewards.Infrastructure/Persistence/Migrations/20220809075120_SeedSocialMediaPlatforms.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
+using SSW.Rewards.Domain.Enums;
 
 #nullable disable
 
@@ -8,9 +9,9 @@ namespace SSW.Rewards.Persistence.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            UpsertSocialMediaPlatforms(migrationBuilder, "GitHub", "Follow SSW on");
-            UpsertSocialMediaPlatforms(migrationBuilder, "LinkedIn", "Follow SSW on");
-            UpsertSocialMediaPlatforms(migrationBuilder, "Twitter", "Follow SSW TV on");
+            UpsertSocialMediaPlatforms(migrationBuilder, "GitHub", "Follow SSW on", AchievementType.Linked, Icons.Github, true, 150);
+            UpsertSocialMediaPlatforms(migrationBuilder, "LinkedIn", "Follow SSW on", AchievementType.Linked, Icons.Linkedin, true, 150);
+            UpsertSocialMediaPlatforms(migrationBuilder, "Twitter", "Follow SSW TV on", AchievementType.Linked, Icons.Twitter, true, 150);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/SSW.Rewards.Infrastructure/SSW.Rewards.Infrastructure.csproj
+++ b/src/SSW.Rewards.Infrastructure/SSW.Rewards.Infrastructure.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="15.0.10" />
+        <PackageReference Include="FluentEmail.Graph" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="6.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.5" />
@@ -20,9 +21,8 @@
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.5" />
-		<PackageReference Include="FluentEmail.Core" Version="2.8.0" />
-		<PackageReference Include="FluentEmail.Razor" Version="2.8.0" />
-		<PackageReference Include="FluentEmail.SendGrid" Version="2.8.0" />
+		<PackageReference Include="FluentEmail.Core" Version="3.0.2" />
+		<PackageReference Include="FluentEmail.Razor" Version="3.0.2" />
 		<PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
 		<PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
     </ItemGroup>

--- a/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
+++ b/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
@@ -67,7 +67,7 @@ public class EmailService : IEmailService
             .To(model.RewardsTeamEmail)
             .CC(model.UserEmail)
             .Subject("Profile deletion request")
-            .UsingTemplate(template, model)
+            .UsingTemplate(template, model, true)
             .SendAsync(cancellationToken);
 
         if (result.Successful)

--- a/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
+++ b/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
@@ -61,9 +61,9 @@ public class EmailService : IEmailService
 
     public async Task<bool> SendProfileDeletionRequest(DeleteProfileEmail model, CancellationToken cancellationToken)
     {
-        var template = "<p>Hi SSW Rewards</p><p>{{username}} has submitted a profile deletion request.</p><p>Hi {{username}},<br><strong>Important: </strong>if you did not request this, please reply to this email letting us know ASAP, and reset your password.</p></p>1. Please delete their profile and all associated data from the following systems:<ul><li>SSW.Rewards</li><li>SSW.Identity</li></ul>.</p><p>2. Reply all 'done'.</p><p>Thanks,</p><p>SSW Rewards Notification Service</p>";
+        var template = "<p>Hi SSW Rewards</p><p>{{username}} has submitted a profile deletion request.</p><p>Hi {{username}},<br><strong>Important: </strong>if you did not request this, please reply to this email letting us know ASAP, and reset your password.</p></p>1. Please delete their profile and all associated data from the following systems:<ul><li>SSW.Rewards</li><li>SSW.Identity</li></ul></p><p>2. Reply all 'done'.</p><p>Thanks,</p><p>SSW Rewards Notification Service</p>";
 
-        var message = template.Replace("{{username", model.UserName);
+        var message = template.Replace("{{username}}", model.UserName);
 
         try
         {

--- a/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
+++ b/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using SSW.Rewards.Application.Common.Interfaces;
 using SSW.Rewards.Application.Common.Models;
+using SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
 
 namespace SSW.Rewards.Infrastructure;
 
@@ -58,8 +59,25 @@ public class EmailService : IEmailService
         }
     }
 
-    public async Task<bool> SendProfileDeletionRequest(string toMail, string toName, CancellationToken cancellationToken)
+    public async Task<bool> SendProfileDeletionRequest(DeleteProfileEmail model, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var template = "<p>Hi SSW Rewards</p><p>@Model.UserName has submitted a profile deletion request.</p></p>1. Please delete their profile and all associated data from the following systems:<ul><li>SSW.Rewards</li><li>SSW.Identity</li></ul>.</p><p>2. Reply all 'done'.</p><p>Thanks,</p><p>SSW Rewards Notification Service</p>";
+
+        var result = await _fluentEmail
+            .To(model.RewardsTeamEmail)
+            .CC(model.UserEmail)
+            .Subject("Profile deletion request")
+            .UsingTemplate(template, model)
+            .SendAsync(cancellationToken);
+
+        if (result.Successful)
+        {
+            return true;
+        }
+        else
+        {
+            _logger.LogError("Error sending email", _fluentEmail);
+            return false;
+        }
     }
 }

--- a/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
+++ b/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
@@ -57,4 +57,9 @@ public class EmailService : IEmailService
             return false;
         }
     }
+
+    public async Task<bool> SendProfileDeletionRequest(string toMail, string toName, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
+++ b/src/SSW.Rewards.Infrastructure/Services/EmailService.cs
@@ -61,23 +61,33 @@ public class EmailService : IEmailService
 
     public async Task<bool> SendProfileDeletionRequest(DeleteProfileEmail model, CancellationToken cancellationToken)
     {
-        var template = "<p>Hi SSW Rewards</p><p>@Model.UserName has submitted a profile deletion request.</p></p>1. Please delete their profile and all associated data from the following systems:<ul><li>SSW.Rewards</li><li>SSW.Identity</li></ul>.</p><p>2. Reply all 'done'.</p><p>Thanks,</p><p>SSW Rewards Notification Service</p>";
+        var template = "<p>Hi SSW Rewards</p><p>{{username}} has submitted a profile deletion request.</p><p>Hi {{username}},<br><strong>Important: </strong>if you did not request this, please reply to this email letting us know ASAP, and reset your password.</p></p>1. Please delete their profile and all associated data from the following systems:<ul><li>SSW.Rewards</li><li>SSW.Identity</li></ul>.</p><p>2. Reply all 'done'.</p><p>Thanks,</p><p>SSW Rewards Notification Service</p>";
 
-        var result = await _fluentEmail
-            .To(model.RewardsTeamEmail)
-            .CC(model.UserEmail)
-            .Subject("Profile deletion request")
-            .UsingTemplate(template, model, true)
-            .SendAsync(cancellationToken);
+        var message = template.Replace("{{username", model.UserName);
 
-        if (result.Successful)
+        try
         {
-            return true;
+            var result = await _fluentEmail
+                .To(model.RewardsTeamEmail)
+                .CC(model.UserEmail)
+                .Subject("Profile deletion request")
+                .Body(message, true)
+                .SendAsync(cancellationToken);
+
+            if (result.Successful)
+            {
+                return true;
+            }
+            else
+            {
+                _logger.LogError("Error sending email", _fluentEmail);
+                return false;
+            }
         }
-        else
+        catch (Exception ex)
         {
-            _logger.LogError("Error sending email", _fluentEmail);
-            return false;
+
+            throw;
         }
     }
 }

--- a/src/WebUI/ClientApp/src/app/web-api-client.ts
+++ b/src/WebUI/ClientApp/src/app/web-api-client.ts
@@ -2429,6 +2429,7 @@ export interface IUserClient {
     myRoles(): Observable<string[]>;
     register(): Observable<FileResponse>;
     upsertUserSocialMediaId(command: UpsertUserSocialMediaId): Observable<number>;
+    deleteMyProfile(): Observable<FileResponse>;
 }
 
 @Injectable({
@@ -2898,6 +2899,52 @@ export class UserClient implements IUserClient {
     
             return _observableOf(result200);
             }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf(null as any);
+    }
+
+    deleteMyProfile(): Observable<FileResponse> {
+        let url_ = this.baseUrl + "/api/User/DeleteMyProfile";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            headers: new HttpHeaders({
+                "Accept": "application/octet-stream"
+            })
+        };
+
+        return this.http.request("post", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processDeleteMyProfile(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processDeleteMyProfile(response_ as any);
+                } catch (e) {
+                    return _observableThrow(e) as any as Observable<FileResponse>;
+                }
+            } else
+                return _observableThrow(response_) as any as Observable<FileResponse>;
+        }));
+    }
+
+    protected processDeleteMyProfile(response: HttpResponseBase): Observable<FileResponse> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (response as any).error instanceof Blob ? (response as any).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200 || status === 206) {
+            const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
+            const fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+            const fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+            return _observableOf({ fileName: fileName, data: responseBlob as any, status: status, headers: _headers });
         } else if (status !== 200 && status !== 204) {
             return blobToText(responseBlob).pipe(_observableMergeMap((_responseText: string) => {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);

--- a/src/WebUI/Controllers/UserController.cs
+++ b/src/WebUI/Controllers/UserController.cs
@@ -84,6 +84,6 @@ public class UserController : ApiControllerBase
     {
         await Mediator.Send(new DeleteMyProfileCommand());
 
-        return Ok():
+        return Ok();
     }
 }

--- a/src/WebUI/Controllers/UserController.cs
+++ b/src/WebUI/Controllers/UserController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using SSW.Rewards.Application.Achievements.Commands.ClaimSocialMediaAchievementForUser;
+using SSW.Rewards.Application.Users.Commands.DeleteMyProfile;
 using SSW.Rewards.Application.Users.Commands.RegisterUser;
 using SSW.Rewards.Application.Users.Commands.UploadProfilePic;
 using SSW.Rewards.Application.Users.Commands.UpsertUserSocialMediaId;
@@ -76,5 +77,13 @@ public class UserController : ApiControllerBase
         }
 
         return Ok(retVal);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult> DeleteMyProfile()
+    {
+        await Mediator.Send(new DeleteMyProfileCommand());
+
+        return Ok():
     }
 }

--- a/src/WebUI/WebAPI.csproj
+++ b/src/WebUI/WebAPI.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.6.0" />
+        <PackageReference Include="Azure.Identity" Version="1.8.2" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0-beta2" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.5" />

--- a/src/WebUI/appsettings.json
+++ b/src/WebUI/appsettings.json
@@ -20,5 +20,10 @@
   },
   "CloudBlobProviderOptions": {
     "ContentStorageConnectionString": "<Add your blob storage connection string>"
-  }  
+  },
+  "GraphSenderOptions": {
+    "ClientId": "<Add to secrets>",
+    "ClientSecret": "<Add to secrets>",
+    "TenantId": "<Add to secrets>"
+  }
 }

--- a/src/WebUI/wwwroot/api/specification.json
+++ b/src/WebUI/wwwroot/api/specification.json
@@ -1826,6 +1826,32 @@
           }
         ]
       }
+    },
+    "/api/User/DeleteMyProfile": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "operationId": "User_DeleteMyProfile",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT": []
+          }
+        ]
+      }
     }
   },
   "components": {


### PR DESCRIPTION
cc: @adamcogan @AntPolkanov 

The latest submission of the mobile app was rejected by Apple, as app store guidelines now require a way within the app for users to request deletion of their data. See: https://developer.apple.com/support/offering-account-deletion-in-your-app/

This PR adds the required functionality to support this in the API. The feature still needs to be added to the mobile app (a separate PR will be created in the SSW.Rewards.Mobile repo for that).

Todo:

- [ ] ~~@wicksipedia Add Graph secrets to repo~~
- [x] Update infrastructure for Graph secrets

**Edit:**
As per my conversation with @wicksipedia on Teams, secrets not done. We will look to set up Keeper integration for secrets, rather than double handling (used by Identity and Rewards, and also required in Keeper too). In the meantime, I will deploy this change and manually add the secrets to KV.